### PR TITLE
Fix keystore when used from worker side

### DIFF
--- a/src/async_task.ts
+++ b/src/async_task.ts
@@ -184,6 +184,9 @@ function innerMessageHandler(obj_arg: any, ep: Endpoint, message: Message) {
   } else {
     obj = obj_arg;
   }
+  if(obj_arg === undefined && store_key === undefined){
+    throw new Error("Internal synclink error!");
+  }
   const argumentList = ((message as any).argumentList || []).map((v: any) => {
     if (v.type === WireValueType.PROXY) {
       return innerMessageHandler(obj_arg, ep, v.message);
@@ -258,17 +261,27 @@ function innerMessageHandler(obj_arg: any, ep: Endpoint, message: Message) {
 }
 
 export function expose(obj_arg: any, ep: Endpoint = globalThis as any) {
+  const wrap = false;
+  exposeInner(obj_arg, ep, wrap);
+}
+
+function exposeInner(obj_arg: any, ep: Endpoint = globalThis as any, wrap : boolean) {
   storeCreate(ep);
   ep.addEventListener("message", async function callback(ev: MessageEvent) {
     if (!ev || !ev.data) {
       return;
     }
     const message = ev.data as Message;
-    const { id, type } = { ...message };
-
+    const { id, type, store_key  } = { store_key:undefined, ...message };
+    if (wrap && store_key === undefined){
+      return;
+    }
     let returnValue;
     try {
-      returnValue = await innerMessageHandler(obj_arg, ep, message);
+      returnValue = innerMessageHandler(obj_arg, ep, message);
+      if(returnValue && returnValue.then) {
+        returnValue = await returnValue;
+      }
     } catch (value) {
       returnValue = { value, [throwMarker]: 0 };
     }
@@ -298,7 +311,9 @@ function closeEndPoint(endpoint: Endpoint) {
 }
 
 export function wrap<T>(ep: Endpoint, target?: any): Remote<T> {
-  return createProxy<T>(ep, { target }) as any;
+  const wrap = true;
+  exposeInner(undefined, ep, wrap);
+  return createProxy<T>(ep, { target}) as any;
 }
 
 function throwIfProxyReleased(isReleased: boolean) {

--- a/src/async_task.ts
+++ b/src/async_task.ts
@@ -184,7 +184,7 @@ function innerMessageHandler(obj_arg: any, ep: Endpoint, message: Message) {
   } else {
     obj = obj_arg;
   }
-  if(obj_arg === undefined && store_key === undefined){
+  if (obj_arg === undefined && store_key === undefined) {
     throw new Error("Internal synclink error!");
   }
   const argumentList = ((message as any).argumentList || []).map((v: any) => {
@@ -265,21 +265,25 @@ export function expose(obj_arg: any, ep: Endpoint = globalThis as any) {
   exposeInner(obj_arg, ep, wrap);
 }
 
-function exposeInner(obj_arg: any, ep: Endpoint = globalThis as any, wrap : boolean) {
+function exposeInner(
+  obj_arg: any,
+  ep: Endpoint = globalThis as any,
+  wrap: boolean,
+) {
   storeCreate(ep);
   ep.addEventListener("message", async function callback(ev: MessageEvent) {
     if (!ev || !ev.data) {
       return;
     }
     const message = ev.data as Message;
-    const { id, type, store_key  } = { store_key:undefined, ...message };
-    if (wrap && store_key === undefined){
+    const { id, type, store_key } = { store_key: undefined, ...message };
+    if (wrap && store_key === undefined) {
       return;
     }
     let returnValue;
     try {
       returnValue = innerMessageHandler(obj_arg, ep, message);
-      if(returnValue && returnValue.then) {
+      if (returnValue && returnValue.then) {
         returnValue = await returnValue;
       }
     } catch (value) {
@@ -313,7 +317,7 @@ function closeEndPoint(endpoint: Endpoint) {
 export function wrap<T>(ep: Endpoint, target?: any): Remote<T> {
   const wrap = true;
   exposeInner(undefined, ep, wrap);
-  return createProxy<T>(ep, { target}) as any;
+  return createProxy<T>(ep, { target }) as any;
 }
 
 function throwIfProxyReleased(isReleased: boolean) {

--- a/tests/fixtures/synclink.test.worker.js
+++ b/tests/fixtures/synclink.test.worker.js
@@ -1,6 +1,5 @@
 importScripts("/base/dist/iife/synclink.js");
 
-
 function usesCallback(callback) {
   return callback(10).syncify();
 }

--- a/tests/fixtures/synclink.test.worker.js
+++ b/tests/fixtures/synclink.test.worker.js
@@ -1,5 +1,10 @@
 importScripts("/base/dist/iife/synclink.js");
 
+
+function usesCallback(callback) {
+  return callback(10).syncify();
+}
+
 async function get_from_main_window(x) {
   return await self.main_window[x];
 }
@@ -62,6 +67,7 @@ function set_global_scope(window) {
 }
 
 Synclink.expose({
+  usesCallback,
   get_from_main_window,
   set_global_scope,
   mainWindowFetchAsync,

--- a/tests/synclink.test.js
+++ b/tests/synclink.test.js
@@ -18,6 +18,17 @@ describe("test syncify", function () {
     this.worker.terminate();
   });
 
+  it("test syncify callback", async function() {
+    let value;
+    let result = await this.worker.usesCallback((x) => {
+      value = x;
+      return x + 12;
+    });
+    expect(value).to.equal(10);
+    expect(result).to.equal(10 + 12);
+  });
+
+
   it("test proxying fetch to main window", async function () {
     const ttt = 999;
     this.worker_scope.ttt = ttt;

--- a/tests/synclink.test.js
+++ b/tests/synclink.test.js
@@ -18,7 +18,7 @@ describe("test syncify", function () {
     this.worker.terminate();
   });
 
-  it("test syncify callback", async function() {
+  it("test syncify callback", async function () {
     let value;
     let result = await this.worker.usesCallback((x) => {
       value = x;
@@ -27,7 +27,6 @@ describe("test syncify", function () {
     expect(value).to.equal(10);
     expect(result).to.equal(10 + 12);
   });
-
 
   it("test proxying fetch to main window", async function () {
     const ttt = 999;
@@ -42,7 +41,9 @@ describe("test syncify", function () {
   });
 
   it("simple schedule sync test", async function () {
-    expect(await this.worker.fetchResponseAttrsWithSyncify("debug.html")).to.equal(
+    expect(
+      await this.worker.fetchResponseAttrsWithSyncify("debug.html"),
+    ).to.equal(
       JSON.stringify({
         type: "basic",
         redirected: false,


### PR DESCRIPTION
Makes `Synclink.wrap` add an event listener to handle execution of a "key" proxy.

The behavior of `releaseProxy` / `__destroy__` is still not very correct though...