### PR TITLE
Fix auto proxied return values

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -47,6 +47,23 @@ export const enum WireValueType {
   ID = "ID",
 }
 
+// It's not possible to automatically generate a set of values from a const enum
+// https://github.com/microsoft/TypeScript/issues/21391
+
+// This dance allows us to hand write the value set in a type safe way -- if a
+// case is added to or removed from the enum without updating the value set,
+// it's a type error.
+const wireValueTypeRecord: Record<keyof typeof WireValueType, number> = {
+  [WireValueType.RAW]: 1,
+  [WireValueType.PROXY]: 1,
+  [WireValueType.THROW]: 1,
+  [WireValueType.HANDLER]: 1,
+  [WireValueType.ID]: 1,
+};
+export const wireValueTypeSet = new Set(
+  Object.keys(wireValueTypeRecord),
+) as Set<keyof typeof WireValueType>;
+
 export interface RawWireValue {
   id?: string;
   type: WireValueType.RAW;
@@ -93,6 +110,25 @@ export const enum MessageType {
   RELEASE = "RELEASE",
   DESTROY = "DESTROY",
 }
+
+// It's not possible to automatically generate a set of values from a const enum
+// https://github.com/microsoft/TypeScript/issues/21391
+
+// This dance allows us to hand write the value set in a type safe way -- if a
+// case is added to or removed from the enum without updating the value set,
+// it's a type error.
+const messageTypeRecord: Record<keyof typeof MessageType, number> = {
+  [MessageType.SET]: 1,
+  [MessageType.GET]: 1,
+  [MessageType.APPLY]: 1,
+  [MessageType.CONSTRUCT]: 1,
+  [MessageType.ENDPOINT]: 1,
+  [MessageType.RELEASE]: 1,
+  [MessageType.DESTROY]: 1,
+};
+export const messageTypeSet = new Set(Object.keys(messageTypeRecord)) as Set<
+  keyof typeof MessageType
+>;
 
 export interface GetMessage {
   id?: MessageID;
@@ -150,3 +186,9 @@ export type Message =
   | EndpointMessage
   | ReleaseMessage
   | DestroyMessage;
+
+type StaticAssert<T extends true> = T;
+type AreDisjoint<S, T> = S & T extends never ? true : false;
+type AssertMessageTypeAndWireTypeAreDisjoint = StaticAssert<
+  AreDisjoint<WireValueType, MessageType>
+>;

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -443,6 +443,24 @@ describe("Synclink in the same realm", function () {
     expect(await obj.counter).to.equal(1);
   });
 
+  it("will wrap unmarked return values", async function () {
+    const thing = Synclink.wrap(this.port1);
+    Synclink.expose(
+      (_) => ({
+        counter: 0,
+        inc() {
+          this.counter += 1;
+        },
+      }),
+      this.port2,
+    );
+    const obj = await thing();
+    console.log(await obj.counter);
+    expect(await obj.counter).to.equal(0);
+    await obj.inc();
+    expect(await obj.counter).to.equal(1);
+  });
+
   it("will wrap marked return values from class instance methods", async function () {
     const thing = Synclink.wrap(this.port1);
     Synclink.expose(SampleClass, this.port2);


### PR DESCRIPTION
When we call a function from the wrapped side, the new message handler added in and WireValueType. If we get a WireValue in the exposeInner handler we can return early.

This is a bit annoying because they are const enums and perversely typescript has no automatic way to list the values of a const enum. (This feature was requested in

https://github.com/microsoft/TypeScript/issues/21391

but the typescript devs did not seem to understand the request? In any case, this self-evidently useful feature is marked as wont-fix.)

To work around this, I set up a way to generate a Set from a const enum with manual duplication of the enum code. This is type checked so that if the two blocks get out of sync at all there will be a type error.

While I was at it I added a static type assertion that WireValueType and MessageType are disjoint.