### PR TITLE
Update types to use SynclinkTask instead of Promise where appropriate

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,6 @@ export const createEndpoint = Symbol("Synclink.endpoint");
 export const releaseProxy = Symbol("Synclink.releaseProxy");
 export const proxyMarker = Symbol("Synclink.proxy");
 
-
 /**
  * Interface of values that were marked to be proxied with `synclink.proxy()`.
  * Can also be implemented by classes.
@@ -32,7 +31,7 @@ type Unpromisify<P> = P extends Promise<infer T> ? T : P;
  * Takes the raw type of a remote property and returns the type that is visible to the local thread on the proxy.
  *
  * Note: This needs to be its own type alias, otherwise it will not distribute over unions.
- * See https://www.typescriptlang.org/docs/handbook/advanced-types.html#distributive-conditional-types
+ * See https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
  */
 type RemoteProperty<T> =
   // If the value is a method, synclink will proxy it automatically.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
+import type { SynclinkTask } from "./task";
+
 export const createEndpoint = Symbol("Synclink.endpoint");
 export const releaseProxy = Symbol("Synclink.releaseProxy");
 export const proxyMarker = Symbol("Synclink.proxy");
+
 
 /**
  * Interface of values that were marked to be proxied with `synclink.proxy()`.
@@ -35,7 +38,7 @@ type RemoteProperty<T> =
   // If the value is a method, synclink will proxy it automatically.
   // Objects are only proxied if they are marked to be proxied.
   // Otherwise, the property is converted to a Promise that resolves the cloned value.
-  T extends Function | ProxyMarked ? Remote<T> : Promisify<T>;
+  T extends Function | ProxyMarked ? Remote<T> : SynclinkTask<T>;
 
 /**
  * Takes the raw type of a property as a remote thread would see it through a proxy (e.g. when passed in as a function
@@ -46,9 +49,7 @@ type RemoteProperty<T> =
  * Note: This needs to be its own type alias, otherwise it will not distribute over unions. See
  * https://www.typescriptlang.org/docs/handbook/advanced-types.html#distributive-conditional-types
  */
-type LocalProperty<T> = T extends Function | ProxyMarked
-  ? Local<T>
-  : Unpromisify<T>;
+type LocalProperty<T> = T extends Function | ProxyMarked ? Local<T> : UnTask<T>;
 
 /**
  * Proxies `T` if it is a `ProxyMarked`, clones it otherwise (as handled by structured cloning and transfer handlers).
@@ -87,8 +88,11 @@ export type LocalObject<T> = { [P in keyof T]: LocalProperty<T[P]> };
  */
 export interface ProxyMethods {
   [createEndpoint]: () => Promise<MessagePort>;
-  [releaseProxy]: () => void;
+  [releaseProxy]: () => SynclinkTask<void>;
 }
+
+type UnTask<T> = T extends SynclinkTask<infer S> ? S : T;
+type MaybePromise<T> = Promise<T> | T;
 
 /**
  * Takes the raw type of a remote object, function or class in the other thread and returns the type as it is visible to
@@ -101,7 +105,7 @@ export type Remote<T> =
     (T extends (...args: infer TArguments) => infer TReturn
       ? (
           ...args: { [I in keyof TArguments]: UnproxyOrClone<TArguments[I]> }
-        ) => Promisify<ProxyOrClone<Unpromisify<TReturn>>>
+        ) => SynclinkTask<ProxyOrClone<Unpromisify<TReturn>>>
       : unknown) &
     // Handle construct signature (if present)
     // The return of construct signatures is always proxied (whether marked or not)
@@ -111,16 +115,11 @@ export type Remote<T> =
             ...args: {
               [I in keyof TArguments]: UnproxyOrClone<TArguments[I]>;
             }
-          ): Promisify<Remote<TInstance>>;
+          ): SynclinkTask<Remote<TInstance>>;
         }
       : unknown) &
     // Include additional special synclink methods available on the proxy.
     ProxyMethods;
-
-/**
- * Expresses that a type can be either a sync or async.
- */
-type MaybePromise<T> = Promise<T> | T;
 
 /**
  * Takes the raw type of a remote object, function or class as a remote thread would see it through a proxy (e.g. when
@@ -136,7 +135,7 @@ export type Local<T> =
       ? (
           ...args: { [I in keyof TArguments]: ProxyOrClone<TArguments[I]> }
         ) => // The raw function could either be sync or async, but is always proxied automatically
-        MaybePromise<UnproxyOrClone<Unpromisify<TReturn>>>
+        MaybePromise<UnproxyOrClone<UnTask<TReturn>>>
       : unknown) &
     // Handle construct signature (if present)
     // The return of construct signatures is always proxied (whether marked or not)
@@ -147,6 +146,6 @@ export type Local<T> =
               [I in keyof TArguments]: ProxyOrClone<TArguments[I]>;
             }
           ): // The raw constructor could either be sync or async, but is always proxied automatically
-          MaybePromise<Local<Unpromisify<TInstance>>>;
+          MaybePromise<Local<UnTask<TInstance>>>;
         }
       : unknown);

--- a/tests/type-checks.ts
+++ b/tests/type-checks.ts
@@ -1,6 +1,7 @@
 import { assert, Has, NotHas, IsAny, IsExact } from "conditional-type-checks";
 
 import * as Synclink from "../src/synclink.js";
+import { SynclinkTask } from "../src/task.js";
 
 async function closureSoICanUseAwait() {
   {
@@ -11,7 +12,7 @@ async function closureSoICanUseAwait() {
     const proxy = Synclink.wrap<typeof simpleNumberFunction>(0 as any);
     assert<IsAny<typeof proxy>>(false);
     const v = proxy();
-    assert<Has<typeof v, Promise<number>>>(true);
+    assert<Has<typeof v, SynclinkTask<number>>>(true);
   }
 
   {
@@ -42,7 +43,7 @@ async function closureSoICanUseAwait() {
     const proxy = Synclink.wrap<typeof functionWithProxy>(0 as any);
     const subproxy = await proxy();
     const prop = subproxy.a;
-    assert<Has<typeof prop, Promise<number>>>(true);
+    assert<Has<typeof prop, SynclinkTask<number>>>(true);
   }
 
   {
@@ -58,10 +59,10 @@ async function closureSoICanUseAwait() {
     }
 
     const proxy = Synclink.wrap<typeof X>(0 as any);
-    assert<Has<typeof proxy, { staticFunc: () => Promise<number> }>>(true);
+    assert<Has<typeof proxy, { staticFunc: () => SynclinkTask<number> }>>(true);
     const instance = await new proxy();
-    assert<Has<typeof instance, { sayHi: () => Promise<string> }>>(true);
-    assert<Has<typeof instance, { g: Promise<number> }>>(true);
+    assert<Has<typeof instance, { sayHi: () => SynclinkTask<string> }>>(true);
+    assert<Has<typeof instance, { g: SynclinkTask<number> }>>(true);
     assert<NotHas<typeof instance, { f: Promise<number> }>>(true);
     assert<IsAny<typeof instance>>(false);
   }
@@ -80,13 +81,13 @@ async function closureSoICanUseAwait() {
     const proxy = Synclink.wrap<typeof x>(0 as any);
     assert<IsAny<typeof proxy>>(false);
     const a = proxy.a;
-    assert<Has<typeof a, Promise<number>>>(true);
+    assert<Has<typeof a, SynclinkTask<number>>>(true);
     assert<IsAny<typeof a>>(false);
     const b = proxy.b;
-    assert<Has<typeof b, () => Promise<number>>>(true);
+    assert<Has<typeof b, () => SynclinkTask<number>>>(true);
     assert<IsAny<typeof b>>(false);
     const subproxy = proxy.c;
-    assert<Has<typeof subproxy, Promise<{ d: number }>>>(true);
+    assert<Has<typeof subproxy, SynclinkTask<{ d: number }>>>(true);
     assert<IsAny<typeof subproxy>>(false);
     const copy = await proxy.c;
     assert<Has<typeof copy, { d: number }>>(true);
@@ -136,13 +137,13 @@ async function closureSoICanUseAwait() {
     assert<IsExact<typeof endp, Promise<MessagePort>>>(true);
 
     assert<IsAny<typeof proxy.prop1>>(false);
-    assert<Has<typeof proxy.prop1, Promise<string>>>(true);
+    assert<Has<typeof proxy.prop1, SynclinkTask<string>>>(true);
 
     const r1 = proxy.methodWithTupleParams(123, "abc");
-    assert<IsExact<typeof r1, Promise<number>>>(true);
+    assert<IsExact<typeof r1, SynclinkTask<number>>>(true);
 
     const r2 = proxy.methodWithTupleParams("abc");
-    assert<IsExact<typeof r2, Promise<number>>>(true);
+    assert<IsExact<typeof r2, SynclinkTask<number>>>(true);
 
     assert<
       IsExact<
@@ -152,12 +153,12 @@ async function closureSoICanUseAwait() {
     >(true);
 
     assert<IsAny<typeof proxy.proxyProp.prop2>>(false);
-    assert<Has<typeof proxy.proxyProp.prop2, Promise<string>>>(true);
-    assert<Has<typeof proxy.proxyProp.prop2, Promise<number>>>(true);
+    assert<Has<typeof proxy.proxyProp.prop2, SynclinkTask<string>>>(true);
+    assert<Has<typeof proxy.proxyProp.prop2, SynclinkTask<number>>>(true);
 
     const r3 = proxy.proxyProp.method("param");
     assert<IsAny<typeof r3>>(false);
-    assert<Has<typeof r3, Promise<number>>>(true);
+    assert<Has<typeof r3, SynclinkTask<number>>>(true);
 
     // @ts-expect-error
     proxy.proxyProp.method(123);
@@ -168,21 +169,27 @@ async function closureSoICanUseAwait() {
     const r4 = proxy.methodWithProxiedReturnValue();
     assert<IsAny<typeof r4>>(false);
     assert<
-      IsExact<typeof r4, Promise<Synclink.Remote<Baz & Synclink.ProxyMarked>>>
+      IsExact<
+        typeof r4,
+        SynclinkTask<Synclink.Remote<Baz & Synclink.ProxyMarked>>
+      >
     >(true);
 
     const r5 = proxy.proxyProp.methodWithProxiedReturnValue();
     assert<
-      IsExact<typeof r5, Promise<Synclink.Remote<Baz & Synclink.ProxyMarked>>>
+      IsExact<
+        typeof r5,
+        SynclinkTask<Synclink.Remote<Baz & Synclink.ProxyMarked>>
+      >
     >(true);
 
     const r6 = (await proxy.methodWithProxiedReturnValue()).baz;
     assert<IsAny<typeof r6>>(false);
-    assert<Has<typeof r6, Promise<number>>>(true);
+    assert<Has<typeof r6, SynclinkTask<number>>>(true);
 
     const r7 = (await proxy.methodWithProxiedReturnValue()).method();
     assert<IsAny<typeof r7>>(false);
-    assert<Has<typeof r7, Promise<number>>>(true);
+    assert<Has<typeof r7, SynclinkTask<number>>>(true);
 
     const ProxiedFooClass = Synclink.wrap<typeof Foo>(
       Synclink.windowEndpoint(self),
@@ -250,7 +257,7 @@ async function closureSoICanUseAwait() {
         assert<
           IsExact<
             typeof resultPromise,
-            Promise<Synclink.Remote<ProxyableSubscribable<string>>>
+            SynclinkTask<Synclink.Remote<ProxyableSubscribable<string>>>
           >
         >(true);
         const result = await resultPromise;
@@ -264,7 +271,7 @@ async function closureSoICanUseAwait() {
         assert<
           IsExact<
             typeof subscriptionPromise,
-            Promise<Synclink.Remote<Unsubscribable & Synclink.ProxyMarked>>
+            SynclinkTask<Synclink.Remote<Unsubscribable & Synclink.ProxyMarked>>
           >
         >(true);
         const subscriber = Synclink.proxy({
@@ -273,7 +280,7 @@ async function closureSoICanUseAwait() {
         result.subscribe(subscriber);
 
         const r1 = (await subscriptionPromise).unsubscribe();
-        assert<IsExact<typeof r1, Promise<void>>>(true);
+        assert<IsExact<typeof r1, SynclinkTask<void>>>(true);
       }
     }
     const proxy2 = Synclink.wrap<Registry>(Synclink.windowEndpoint(self));
@@ -294,7 +301,10 @@ async function closureSoICanUseAwait() {
             assert<
               IsExact<
                 typeof subscriber.closed,
-                Promise<true> | Promise<false> | Promise<undefined> | undefined
+                | SynclinkTask<true>
+                | SynclinkTask<false>
+                | SynclinkTask<undefined>
+                | undefined
               >
             >(true);
 
@@ -303,7 +313,7 @@ async function closureSoICanUseAwait() {
               IsExact<
                 typeof subscriber.next,
                 | Synclink.Remote<(value: string) => void>
-                | Promise<undefined>
+                | SynclinkTask<undefined>
                 | undefined
               >
             >(true);
@@ -342,7 +352,7 @@ async function closureSoICanUseAwait() {
               IsExact<
                 typeof subscriber.next,
                 | Synclink.Remote<(value: string) => void>
-                | Promise<undefined>
+                | SynclinkTask<undefined>
                 | undefined
               >
             >(true);


### PR DESCRIPTION
When we changed the return type of a bunch of stuff to return `SynclinkTask`s 
instead of Promises we didn't update the type logic. This updates the type logic to use `SynclinkTask`. 
We also add return types to all the `SynclinkTask` methods.

Originally, `Remote<T>` did roughly:

```ts
Promisify<ProxyOrClone<Unpromisify<T>>>
```

where `Unpromisify<T>` converts `Promise<T>` to `T` and leaves everything else alone and `Promisify` leaves `Promise<T>` alone and converts other `T` to `Promise<T>`.

`Local<T>` did almost the inverse, but `Unpromisify` and `Promisify` aren't invertible so 
`Promisify<Unpromisify<T>>` has to be replaced with `MaybePromise<T>`:

```ts
MaybePromise<UnproxyOrClone<Unpromisify<T>>>
```

We convert `Remote<T>` to do:

```ts
SynclinkTask<ProxyOrClone<Unpromisify<T>>>
```

and then `Local<T> does the ~almost inverse:

```ts
MaybePromise<UnproxyOrClone<UnTask<T>>>
```