### PR TITLE
Update repository URL in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/hoodmane/synclink.git"
+    "url": "https://github.com/pyodide/synclink.git"
   },
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
Looks like the development is now happening in https://github.com/pyodide/synclink, while https://github.com/hoodmane/synclink is now a fork.