### PR TITLE
Fix missing type declaration entry in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "dist/types/synclink.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/synclink.d.ts",
       "require": "./dist/cjs/synclink.js",
       "import": "./dist/esm/synclink.mjs"
     }


### PR DESCRIPTION
Typescript is complaining _"Could not find a declaration file for module 'synclink'."_ because in 3bd11dc54dab6c620a6631c039feb0954a1da5a4, you added an `exports` field in `package.json`, but `synclink.d.ts` is missed.